### PR TITLE
Add conv2d_groups

### DIFF
--- a/conv2d.py
+++ b/conv2d.py
@@ -124,17 +124,11 @@ def extract_sliding_windows_gradw(x, ksize, pad, stride, orig_size, floor_first=
     y : np.array
         Sliding window: [N, H', W', KH, KW, C]
     """
-    n = x.shape[0]
-    h = x.shape[1]
-    w = x.shape[2]
-    c = x.shape[3]
-    kh = ksize[0]
-    kw = ksize[1]
-    sh = stride[0]
-    sw = stride[1]
+    n, h, w, c = x.shape
+    kh, kw = ksize
+    sh, sw = stride
 
-    h2 = orig_size[0]
-    w2 = orig_size[1]
+    h2, w2 = orig_size
     ph = int(calc_pad(pad, h, h2, 1, ((kh - 1) * sh + 1)))
     pw = int(calc_pad(pad, w, w2, 1, ((kw - 1) * sw + 1)))
 
@@ -205,19 +199,12 @@ def extract_sliding_windows_gradx(x, ksize, pad, stride, orig_size, floor_first=
     y : np.array
         Sliding window: [N, H, W, KH, KW, C]
     """
-    n = x.shape[0]
-    h = x.shape[1]
-    w = x.shape[2]
-    c = x.shape[3]
-    kh = ksize[0]
-    kw = ksize[1]
-    ph = pad[0]
-    pw = pad[1]
-    sh = stride[0]
-    sw = stride[1]
-    h2 = orig_size[0]
-    w2 = orig_size[1]
-    xs = np.zeros([n, x.shape[1], sh, x.shape[2], sw, c])
+    n, h, w, c = x.shape
+    kh, kw = ksize
+    ph, pw = pad
+    sh, sw = stride
+    h2, w2 = orig_size
+    xs = np.zeros([n, h, sh, w, sw, c])
     xs[:, :, 0, :, 0, :] = x
     xss = xs.shape
     x = xs.reshape([xss[0], xss[1] * xss[2], xss[3] * xss[4], xss[5]])
@@ -271,14 +258,9 @@ def extract_sliding_windows(x, ksize, pad, stride, floor_first=True):
     y : np.array
         Sliding window: [N, (H-KH+PH+1)/SH, (W-KW+PW+1)/SW, KH * KW, C]
     """
-    n = x.shape[0]
-    h = x.shape[1]
-    w = x.shape[2]
-    c = x.shape[3]
-    kh = ksize[0]
-    kw = ksize[1]
-    sh = stride[0]
-    sw = stride[1]
+    n, h, w, c = x.shape
+    kh, kw = ksize
+    sh, sw = stride
 
     h2 = int(calc_size(h, kh, pad, sh))
     w2 = int(calc_size(w, kw, pad, sw))

--- a/conv2d.py
+++ b/conv2d.py
@@ -142,12 +142,7 @@ def extract_sliding_windows_gradw(x, ksize, pad, stride, orig_size, floor_first=
     else:
         pph = (ph2, ph3)
         ppw = (pw2, pw3)
-    x = np.pad(
-        x,
-        ((0, 0), (ph3, ph2), (pw3, pw2), (0, 0)),
-        mode="constant",
-        constant_values=(0.0,),
-    )
+    x = np.pad(x, ((0, 0), pph, ppw, (0, 0)), mode="constant", constant_values=(0.0,))
     p2h = (-x.shape[1]) % sh
     p2w = (-x.shape[2]) % sw
     if p2h > 0 or p2w > 0:

--- a/test_conv2d.py
+++ b/test_conv2d.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 import tensorflow as tf
 
-from conv2d import conv2d, conv2d_gradw, conv2d_gradx
+from conv2d import conv2d, conv2d_gradw, conv2d_gradx, conv2d_groups
 
 
 @pytest.mark.parametrize("ii", range(5))
@@ -71,3 +71,20 @@ def test_conv2d_gradx(ii, stride, kernel_size, pad, rng):
         dww = tape.gradient(yy, xx, output_gradients=dyy)
     dx_tf = dww.numpy()
     assert np.allclose(dx.ravel(), dx_tf.ravel())
+
+
+@pytest.mark.parametrize("ii", range(2))
+@pytest.mark.parametrize("stride", [(1, 1), (2, 2), (3, 2)])
+@pytest.mark.parametrize("kernel_size", [(1, 1), (4, 5), (5, 4), (5, 5)])
+@pytest.mark.parametrize("groups", [1, 2, 3])
+@pytest.mark.parametrize("pad", ["SAME", "VALID"])
+def test_conv2d_groups(ii, stride, kernel_size, groups, pad, rng):
+    x = rng.rand(3, 5, 5, 2 * groups).astype("float32")
+    w = rng.rand(*(kernel_size + (2, 1 * groups))).astype("float32")
+
+    y = conv2d_groups(x, w, pad=pad, stride=stride).ravel()
+    xx = tf.constant(x, dtype="float32")
+    ww = tf.constant(w, dtype="float32")
+    yy = tf.nn.conv2d(xx, ww, strides=[1, stride[0], stride[1], 1], padding=pad)
+    y_tf = yy.numpy()
+    assert np.allclose(y, y_tf.ravel())


### PR DESCRIPTION
These are changes we've made recently to np-conv2d in https://github.com/nengo/nengo recently to support grouped convolutions as `tf.nn.conv2d` does. Like`tf.nn.conv2d`, we infer the number of groups from the input and weights shapes.

There are also some other small fixes this PR, which builds on #3. I think after this and #3 are merged we should do a release on PyPI.